### PR TITLE
fix: 修复静态路由也会被自动放置在MainLayout下的问题

### DIFF
--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -57,6 +57,12 @@ for (const path in pages) {
     addRouteRecursive(segments, component, mainLayoutRoute.children!);
 }
 
+// 移除与静态路由重复的页面路由
+const staticPaths = new Set(staticRoutes.map((route) => route.path.slice(1))); // 裁切掉第一个'/'
+mainLayoutRoute.children = mainLayoutRoute.children!.filter(
+    (route) => !staticPaths.has(route.path),
+);
+
 // 移除 otherRoutes，因为所有页面已嵌套到 MainLayout
 const otherRoutes: RouteRecordRaw[] = [];
 

--- a/src/routers/staticRoutes.ts
+++ b/src/routers/staticRoutes.ts
@@ -1,7 +1,12 @@
-import type { RouteRecordRaw } from "vue-router";
+import type { RouteRecordRaw } from 'vue-router';
 
 const staticRoutes: RouteRecordRaw[] = [
-    // 可在此添加静态路由
+    // 可在此添加静态路由，页面不会加到MainLayout下面
+    {
+        name: 'Chat',
+        path: '/chat',
+        component: () => import('@/pages/chat/index.vue'),
+    },
 ];
 
 export default staticRoutes;

--- a/src/routers/utils.ts
+++ b/src/routers/utils.ts
@@ -32,7 +32,7 @@ export function addRouteRecursive(
             .replace(/\.vue$/, '')
             .replace(/\[(\w+)\]/g, ':$1') // 动态参数
             .replace(/Page$/, '') // 移除Page后缀
-            .replace(/home$/i, '') // index.vue 代表父级路径
+            .replace(/index$/i, '') // index.vue 代表父级路径
             .toLowerCase() || '';
 
     let existingRoute = parentRoutes.find(


### PR DESCRIPTION
现在开始，如果不想让文件嵌入在`MainLayout`布局下面，需要将其添加到`src/routers/staticRoutes.ts`下面：
比如`Chat`页面不想放在`MainLayout`布局下面，我们就按照这样的写法：
```ts
import type { RouteRecordRaw } from 'vue-router';

const staticRoutes: RouteRecordRaw[] = [
    // 可在此添加静态路由，页面不会加到MainLayout下面
    {
        name: 'Chat',
        path: '/chat',
        component: () => import('@/pages/chat/index.vue'),
    },
];

export default staticRoutes;
```