### PR TITLE
fix: 解决跨域问题

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,7 @@
 NODE_ENV=development
 
 # API 基础地址 - 开发环境
-VITE_API_BASE_URL=http://120.78.76.80:8080/
+VITE_API_BASE_URL=
 
 # 开发环境特有配置
 VITE_APP_ENV=development

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,83 +3,81 @@
  */
 
 export interface EnvConfig {
-    API_BASE_URL: string;
-    APP_TITLE: string;
-    APP_VERSION: string;
-    APP_ENV: string;
-    DEBUG: boolean;
+  API_BASE_URL: string;
+  APP_TITLE: string;
+  APP_VERSION: string;
+  APP_ENV: string;
+  DEBUG: boolean;
 }
 
 class Environment {
-    private config: EnvConfig;
+  private config: EnvConfig;
 
-    constructor() {
-        this.config = {
-            API_BASE_URL:
-                import.meta.env.VITE_API_BASE_URL ||
-                'http://localhost:3000/api',
-            APP_TITLE: import.meta.env.VITE_APP_TITLE || 'NewBeall Repository',
-            APP_VERSION: import.meta.env.VITE_APP_VERSION || '1.0.0',
-            APP_ENV: import.meta.env.VITE_APP_ENV || 'development',
-            DEBUG: import.meta.env.VITE_DEBUG === 'true' || false,
-        };
-    }
+  constructor() {
+    this.config = {
+      API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+      APP_TITLE: import.meta.env.VITE_APP_TITLE || 'NewBeall Repository',
+      APP_VERSION: import.meta.env.VITE_APP_VERSION || '1.0.0',
+      APP_ENV: import.meta.env.VITE_APP_ENV || 'development',
+      DEBUG: import.meta.env.VITE_DEBUG === 'true' || false,
+    };
+  }
 
-    /**
-     * 获取 API 基础 URL
-     */
-    getApiBaseUrl(): string {
-        return this.config.API_BASE_URL;
-    }
+  /**
+   * 获取 API 基础 URL
+   */
+  getApiBaseUrl(): string {
+    return this.config.API_BASE_URL;
+  }
 
-    /**
-     * 获取应用标题
-     */
-    getAppTitle(): string {
-        return this.config.APP_TITLE;
-    }
+  /**
+   * 获取应用标题
+   */
+  getAppTitle(): string {
+    return this.config.APP_TITLE;
+  }
 
-    /**
-     * 获取应用版本
-     */
-    getAppVersion(): string {
-        return this.config.APP_VERSION;
-    }
+  /**
+   * 获取应用版本
+   */
+  getAppVersion(): string {
+    return this.config.APP_VERSION;
+  }
 
-    /**
-     * 获取当前环境
-     */
-    getAppEnv(): string {
-        return this.config.APP_ENV;
-    }
+  /**
+   * 获取当前环境
+   */
+  getAppEnv(): string {
+    return this.config.APP_ENV;
+  }
 
-    /**
-     * 是否为开发环境
-     */
-    isDevelopment(): boolean {
-        return this.config.APP_ENV === 'development';
-    }
+  /**
+   * 是否为开发环境
+   */
+  isDevelopment(): boolean {
+    return this.config.APP_ENV === 'development';
+  }
 
-    /**
-     * 是否为生产环境
-     */
-    isProduction(): boolean {
-        return this.config.APP_ENV === 'production';
-    }
+  /**
+   * 是否为生产环境
+   */
+  isProduction(): boolean {
+    return this.config.APP_ENV === 'production';
+  }
 
-    /**
-     * 是否开启调试模式
-     */
-    isDebug(): boolean {
-        return this.config.DEBUG;
-    }
+  /**
+   * 是否开启调试模式
+   */
+  isDebug(): boolean {
+    return this.config.DEBUG;
+  }
 
-    /**
-     * 获取完整配置
-     */
-    getConfig(): EnvConfig {
-        return { ...this.config };
-    }
+  /**
+   * 获取完整配置
+   */
+  getConfig(): EnvConfig {
+    return { ...this.config };
+  }
 }
 
 const env = new Environment();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,4 +48,15 @@ export default defineConfig({
       // 使用css modules时，需要用驼峰式来访问类名，如style.buttonColor而不是style['button-color']
     },
   },
+  // 服务器配置(解决跨域问题)
+  server: {
+    host: '0.0.0.0', // 允许外部访问
+    proxy: {
+      '/api': {
+        target: 'http://120.78.76.80:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
This pull request includes changes to improve environment configuration and add server proxy settings for development. The most important updates involve removing hardcoded API base URLs, centralizing configuration in the environment variables, and addressing cross-origin issues with a proxy setup.

### Environment Configuration Updates:
* [`.env.development`](diffhunk://#diff-da4c41d59c967338247b2f0ea6d845ab05171f942fd9521b96d3304202185db9L5-R5): Removed the hardcoded value for `VITE_API_BASE_URL` in the development environment, leaving it blank to be defined dynamically or externally.
* [`src/utils/env.ts`](diffhunk://#diff-ff9fe1e089b0f33fe0d0f46047d4ce2d9d95cd3cfb6f7f816bde029e485aba0fL18-R18): Updated the `Environment` class to remove the fallback hardcoded API base URL (`http://localhost:3000/api`) and rely solely on `import.meta.env.VITE_API_BASE_URL`.

### Server Proxy Configuration:
* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR51-R61): Added a `server` configuration block to enable a proxy for API requests, addressing cross-origin issues. The proxy forwards requests starting with `/api` to `http://120.78.76.80:8080`, removes the `/api` prefix, and allows external access by setting the host to `0.0.0.0`.