### PR TITLE
fix(service): 修改部分ws代理服务器内置转发规则/删除冗余代码/兼容ChatAPI到最新的http实例/新增Dashboar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ npm i
 npm run dev
 ```
 
+如需使用WebSocket代理，请一并启动WebSocket代理服务器
+
+安装
+```bash
+cd proxy-server
+npm i
+```
+
+启动
+```bash
+npm run dev
+```
+
 ### 3. 打包项目
 
 ```bash

--- a/proxy-server/server.js
+++ b/proxy-server/server.js
@@ -224,19 +224,7 @@ wss.on('connection', (clientWs, req) => {
           messageToSend = JSON.stringify(data);
         } catch {
           console.log('[WebSocket] 服务器消息不是JSON格式，作为文本发送:', messageStr.substring(0, 100) + '...');
-          // 如果不是JSON，尝试包装成JSON格式
-          try {
-            const wrappedMessage = {
-              type: 'text',
-              content: messageStr,
-              timestamp: Date.now()
-            };
-            messageToSend = JSON.stringify(wrappedMessage);
-            console.log('[WebSocket] 已将文本消息包装为JSON格式');
-          } catch {
-            // 如果包装失败，直接发送文本
-            messageToSend = messageStr;
-          }
+          messageToSend = messageStr;
         }
 
         // 确保发送给客户端的是JSON格式

--- a/src/api/chat/chatApi.ts
+++ b/src/api/chat/chatApi.ts
@@ -10,14 +10,12 @@ import type {
 
 // 获取当前用户
 export const getMe = async () => {
-  const res = await http.post<{ data: UserInfo }>('/mgr/me');
-  return res.data;
+  return await http.post<UserInfo>('/mgr/me');
 };
 
 // 获取管理员信息
 export const getAdminInfo = async () => {
-  const res = await http.get<{ data: UserInfo }>('/mgr/getAdmin');
-  return res.data;
+  return await http.get<UserInfo>('/mgr/getAdmin');
 };
 
 // 获取可以新建群聊的用户列表
@@ -29,47 +27,41 @@ export const getCanCreateGroupUserList = async (roleOutMe: boolean) => {
       'Content-Type': 'multipart/form-data',
     },
   });
-  return res.data;
+  return res;
 };
 
 // 获取消息列表通用接口
 export const getAnyMessageList = async (url: string) => {
-  const res = await http.post<{ data: ChatInfo[] | ContactInfo[] }>(url);
-  return res.data;
+  return await http.post<ChatInfo[] | ContactInfo[]>(url);
 };
 
 // 获取未读用户列表
 export const getUnreadUserList = async (read: number[], unread: number[]) => {
-  const res = await http.post<{read: number[], unread: number[]} ,{ data: { read: UserInfo[]; unRead: UserInfo[] } }>(
+  return await http.post<{read: number[], unread: number[]} ,{ read: UserInfo[]; unRead: UserInfo[] }>(
     '/mgr/msgReadPersons',
     { read, unread },
   );
-  return res.data;
 };
 
 // 消息发送控制器
 // 发送消息
 export const sendMessage = async (chatMsg: ChatMessage) => {
-  const res = await http.post<null, ChatMessage>('/chatMessage', null, { params: chatMsg});
-  return res.data;
+  return await http.post<null, ChatMessage>('/chatMessage', null, { params: chatMsg});
 };
 
 // 获取临时聊天框;
 export const getTempWindow = async () => {
-  const res = await http.get<{ data: ChatInfo[] }>('/chatMessage/getTempWindow');
-  return res.data;
+  return await http.get<ChatInfo[]>('/chatMessage/getTempWindow');
 };
 
 // 获取用户未读消息数量
 export const getUnreadMsgCount = async (count: number) => {
-  const res = await http.get(`/chatMessage/getUnreadCount/${count}`);
-  return res.data;
+  return await http.get(`/chatMessage/getUnreadCount/${count}`);
 };
 
 // 标注消息已读
 export const setMessageRead = async (toKey: string, id: string) => {
-  const res = await http.get(`/chatMessage/read/${toKey}/${id}`);
-  return res.data;
+  return await http.get(`/chatMessage/read/${toKey}/${id}`);
 };
 
 // 存储临时聊天框
@@ -90,91 +82,78 @@ export const saveTempWindow = async (params: {
       'Content-Type': 'multipart/form-data',
     },
   });
-  return res.data;
+  return res;
 };
 
 // 获取消息
 export const getMessages = async (toKey: string) => {
-  const res = await http.get<{ data: ChatMessage[] }>(`/chatMessage/${toKey}`);
-  return res.data;
+  return await http.get<ChatMessage[]>(`/chatMessage/${toKey}`);
 };
 
 // 消息管理
 // 单条记录标记为已读
 export const setSingleMessageRead = async (id: string) => {
-  const res = await http.get(`/message/msgRead?id=${id}`);
-  return res.data;
+  return await http.get(`/message/msgRead?id=${id}`);
 };
 
 // 批量标注已读
 export const setAllMessagesRead = async (ids: string[]) => {
-  const res = await http.post(`/message/msgReadAll?ids[]=${ids}`);
-  return res.data;
+  return await http.post(`/message/msgReadAll?ids[]=${ids}`);
 };
 
 // 删除消息记录
 export const deleteMessage = async (orderId: string) => {
-  const res = await http.get(`/message/msgReadByOrder?orderId=${orderId}`);
-  return res.data;
+  return await http.get(`/message/msgReadByOrder?orderId=${orderId}`);
 };
 
 // 群聊人员控制器
 // 加入群聊
 export const joinGroup = async (toKey: string, userIds: string[]) => {
-  const res = await http.post(`/chatGroupUser/joinGroup/${toKey}`, userIds);
-  return res.data;
+  return await http.post(`/chatGroupUser/joinGroup/${toKey}`, userIds);
 };
 
 // 根据聊天id获取群成员
 export const getGroupMembers = async (toKey: string) => {
-  const res = await http.get<{ data: UserInfo[] }>(`/chatGroupUser/list/${toKey}`);
-  return res.data;
+  return await http.get<UserInfo[]>(`/chatGroupUser/list/${toKey}`);
 };
 
 // 获取某个公司未加入指定群聊的人员
 export const getNotJoinMember = async (groupId: string) => {
-  const res = await http.get<{ data: UserInfo[] }>(
+  return await http.get<UserInfo[]>(
     `/chatGroupUser/listNotJoinGroup/${groupId}`,
   );
-  return res.data;
 };
 
 // 群聊控制器
 // 创建群组
 export const createGroup = async (chatName: string, userIds: number[]) => {
-  const res = await http.post('/chatGroup', { chatName, userIds });
-  return res.data;
+  return await http.post('/chatGroup', { chatName, userIds });
 };
 
 // 获取当前登录用户加入的群组
 export const getJoinGroupList = async () => {
-  const res = await http.get('/chatGroup/joinGroupList');
-  return res.data;
+  return await http.get('/chatGroup/joinGroupList');
 };
 
 // 聊天控制器
 // 获取公司信息
 export const getCompanyInfo = async (ToKey: string) => {
-  const res = await http.get<{ data: CompanyInfo }>(`/chat/companyGroup/${ToKey}`);
-  return res.data;
+  return await http.get<CompanyInfo>(`/chat/companyGroup/${ToKey}`);
 };
 
 //  删除聊天
 export const deleteChat = async (toKey: string) => {
-  const res = await http.delete(`/chat/tempChat/${toKey}`);
-  return res.data;
+  return await http.delete(`/chat/tempChat/${toKey}`);
 };
 
 // 聊天联系人分组控制器
 // 获取聊天联系分组
 export const getContactGroup = async () => {
-  const res = await http.get<{ data: ContactGroup[] }>('/chatContactModel');
-  return res.data;
+  return await http.get<ContactGroup[]>('/chatContactModel');
 };
 
 
 // 提交意见
 export const submitFeedback = async (feedback: string, phone: string) => {
-  const res = await http.get('/suggest/add', { sugtext: feedback, phone });
-  return res.data;
+  return await http.get('/suggest/add', { sugtext: feedback, phone });
 };

--- a/src/pages/chat/index.vue
+++ b/src/pages/chat/index.vue
@@ -24,9 +24,7 @@ onMounted(async () => {
   if (userId.value.length > 0) {
     console.log('🚀 初始化聊天页面WebSocket连接...');
     // 创建聊天WebSocket实例，传入用户ID
-    wsClient = createChatWebSocket({
-      userId: userId.value
-    });
+    wsClient = createChatWebSocket(userId.value);
     // 启动WebSocket连接
     wsClient.connect();
     console.log('✅ 聊天WebSocket实例已创建并启动');

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -4,10 +4,11 @@ import env from './env';
 // 默认配置常量
 export const DEFAULT_RECONNECT_ATTEMPTS = 5; // 默认重连尝试次数
 export const DEFAULT_RECONNECT_INTERVAL = 2000; // 默认重连间隔时间（毫秒）
-export const DEFAULT_HEARTBEAT_INTERVAL = 20000; // 默认心跳间隔时间（毫秒）- 60秒
-export const DEFAULT_HEARTBEAT_TIMEOUT = 10000; // 默认心跳超时时间（毫秒）- 15秒
+export const DEFAULT_HEARTBEAT_INTERVAL = 36000; // 默认心跳间隔时间（毫秒）- 36秒
+export const DEFAULT_HEARTBEAT_TIMEOUT = 5000; // 默认心跳超时时间（毫秒）- 5秒
 // export const DEFAULT_PING_MESSAGE = JSON.stringify({ type: 'ping' }); // 默认心跳消息
 export const DEFAULT_PING_MESSAGE = 'ping'; // 默认心跳消息
+export const DEFAULT_PONG_MESSAGE = 'ping'; // 默认心跳回复消息
 
 // WebSocket 关闭状态码
 export const WEBSOCKET_NORMAL_CLOSE_CODE = 1000; // 正常关闭
@@ -26,8 +27,6 @@ export interface WebSocketOptions {
   heartbeatInterval?: number; // 心跳间隔时间（毫秒）
   heartbeatTimeout?: number; // 心跳超时时间（毫秒）
   pingMessage?: string; // 心跳消息内容
-  // 自动管理配置
-  autoManage?: boolean; // 是否自动管理连接（页面关闭时自动断开）
   // 事件回调
   onOpen?: (event: Event) => void; // 连接成功时的回调
   onMessage?: (event: MessageEvent) => void; // 收到消息时的回调函数
@@ -71,10 +70,7 @@ export class WebSocketClient {
   private targetPath: string;
   private isDevelopment: boolean;
 
-  // 自动管理相关
-  private autoManage: boolean;
   private isDestroyed = false;
-  private eventListeners: Array<() => void> = [];
 
   private onOpenCallback?: (event: Event) => void;
   private onMessageCallback?: (event: MessageEvent) => void;
@@ -86,7 +82,6 @@ export class WebSocketClient {
     this.targetPath = options.targetPath;
     this.protocols = options.protocols;
     this.isDevelopment = env.isDevelopment();
-    this.autoManage = options.autoManage ?? true; // 默认启用自动管理
 
     // 构建WebSocket URL
     this.url = this.buildWebSocketUrl();
@@ -108,12 +103,6 @@ export class WebSocketClient {
     console.log(`🌍 当前环境: ${env.getAppEnv()}`);
     console.log(`🔌 WebSocket模式: ${this.isDevelopment ? '开发代理模式' : '生产直连模式'}`);
     console.log(`🔗 WebSocket URL: ${this.url}`);
-
-    // 如果启用自动管理，设置页面事件监听器
-    if (this.autoManage) {
-      this.setupAutoDisconnectListeners();
-      console.log('🎛️ 已启用WebSocket自动管理模式');
-    }
 
     // 监听网络状态变化
     this.setupNetworkListeners();
@@ -274,12 +263,6 @@ export class WebSocketClient {
       this.socket = null;
     }
 
-    // 如果启用了自动管理，移除所有事件监听器
-    if (this.autoManage) {
-      this.eventListeners.forEach(cleanup => cleanup());
-      this.eventListeners = [];
-    }
-
     // 重置状态
     this.isConnected.value = false;
     this.isConnecting.value = false;
@@ -338,16 +321,14 @@ export class WebSocketClient {
     // 更新最后心跳时间
     this.lastHeartbeatTime = Date.now();
 
-    // 检查是否是pong消息
-    try {
-      const data = JSON.parse(event.data);
-      if (data.type === 'pong') {
-        console.log('✅ 收到心跳回复pong！连接正常');
-        return; // 不传递pong消息给业务回调
-      }
-    } catch {
-      // 不是JSON格式，也更新心跳时间（任何消息都表示连接活跃）
-      console.log('收到非JSON格式消息，连接活跃');
+    // 检查是否是服务器回复的心跳ping消息
+    const data = event.data;
+    if (data === DEFAULT_PONG_MESSAGE) {
+      console.log(`✅ 收到心跳回复${DEFAULT_PONG_MESSAGE} 连接正常`);
+      return; // 不传递心跳回复消息给业务回调
+    } else {
+      // 不是心跳回复消息，也更新心跳时间（任何消息都表示连接活跃）
+      console.log('收到其他消息，连接活跃');
     }
 
     if (this.onMessageCallback) {
@@ -441,7 +422,7 @@ export class WebSocketClient {
       if (this.isConnected.value && this.socket) {
         // 发送心跳消息
         const pingResult = this.send(this.pingMessage);
-        console.log('发送心跳消息', pingResult ? '成功' : '失败');
+        console.log(`发送心跳消息 ${this.pingMessage} `, pingResult ? '成功' : '失败');
 
         // 设置心跳超时检测
         this.heartbeatTimeoutTimer = window.setTimeout(() => {
@@ -476,42 +457,6 @@ export class WebSocketClient {
   }
 
   /**
-   * 设置自动断开连接的事件监听器
-   */
-  private setupAutoDisconnectListeners(): void {
-    if (typeof window === 'undefined') return;
-
-    // const handleBeforeUnload = () => {
-    //   console.log('🚨 检测到页面即将关闭，自动断开WebSocket连接');
-    //   this.disconnect();
-    // };
-
-    const handleUnload = () => {
-      console.log('🚨 页面正在卸载，强制断开WebSocket连接');
-      this.disconnect();
-    };
-
-    // const handleVisibilityChange = () => {
-    //   if (document.visibilityState === 'hidden') {
-    //     console.log('🚨 页面变为不可见，自动断开WebSocket连接');
-    //     this.disconnect();
-    //   }
-    // };
-
-    // 添加事件监听器
-    // window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('unload', handleUnload);
-    // document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    // 保存清理函数
-    this.eventListeners.push(
-      // () => window.removeEventListener('beforeunload', handleBeforeUnload),
-      () => window.removeEventListener('unload', handleUnload),
-      // () => document.removeEventListener('visibilitychange', handleVisibilityChange)
-    );
-  }
-
-  /**
    * 设置网络状态监听器。
    * 在网络恢复时自动尝试重连。
    */
@@ -531,16 +476,7 @@ export class WebSocketClient {
       });
     }
   }
-
-  /**
-   * 检查客户端是否已销毁
-   */
-  public get destroyed(): boolean {
-    return this.isDestroyed;
-  }
 }
-
-
 
 /**
  * 创建通用WebSocket连接 - 完全自定义配置
@@ -550,43 +486,3 @@ export function createWebSocket(options: Omit<WebSocketOptions, 'url'>): WebSock
   return new WebSocketClient(options);
 }
 
-
-
-
-// 示例用法:
-/*
-// 通用WebSocket客户端使用方式
-import { WebSocketClient, createWebSocket } from '@/utils/websocket';
-
-// 方式1：使用工厂函数（推荐）
-const wsClient = createWebSocket({
-  targetPath: '/your-websocket-path',
-  autoManage: true, // 启用自动管理
-  onOpen: () => console.log('连接成功'),
-  onMessage: (event) => console.log('收到消息:', event.data),
-});
-
-// 方式2：直接使用类
-const wsClient = new WebSocketClient({
-  targetPath: '/your-custom-path',
-  autoManage: true, // 启用自动管理
-  customOrigin: 'http://your-dev-server.com',     // 仅开发环境
-  productionWSUrl: 'wss://your-prod-domain.com',  // 仅生产环境
-  cookies: { token: 'abc123' },                   // 额外cookies
-  heartbeatInterval: 30000,
-  heartbeatTimeout: 15000,
-  // 事件回调...
-});
-
-wsClient.connect();
-
-特性：
-1. 🌍 环境自动检测：开发环境使用代理，生产环境直连
-2. 🍪 HttpOnly Cookie支持：开发环境自动转发cookies
-3. 💓 智能心跳：自动检测连接状态并重连
-4. 🧹 自动清理：autoManage模式自动处理资源清理
-5. 📊 详细日志：清晰的连接状态和错误信息
-6. ⚙️ 灵活配置：支持完全自定义配置
-
-注意：聊天相关功能请使用 @/websocket/chat 模块
-*/

--- a/src/websocket/chat.ts
+++ b/src/websocket/chat.ts
@@ -5,15 +5,13 @@
 import { WebSocketClient } from '@/utils/websocket';
 
 /**
- * 创建聊天WebSocket连接 - 基础工厂函数
- * 自动根据环境选择代理或直连模式，启用自动管理
+ * 创建聊天WebSocket连接
+ * @param userId 用户ID
+ * @returns WebSocketClient
  */
-export function createChatWebSocket(options: {
-  userId: string | number;
-}): WebSocketClient {
+export function createChatWebSocket(userId: string | number): WebSocketClient {
   return new WebSocketClient({
-    targetPath: `/chatServe/${options.userId}`,
-    autoManage: false, // 启用自动管理，页面关闭时自动断开
+    targetPath: `/chatServe/${userId}`,
     onOpen: (() => {
       console.log('🎉 聊天连接已建立，可以开始聊天了!');
     }),

--- a/src/websocket/dashboard.ts
+++ b/src/websocket/dashboard.ts
@@ -1,0 +1,26 @@
+import { WebSocketClient } from '@/utils/websocket';
+
+/**
+ * 创建首页仪表盘WebSocket连接
+ * @param userId 用户ID
+ * @param index 仪表盘索引
+ * @returns WebSocketClient
+ */
+export function createDashBoardWebSocket(userId: string | number, index: number): WebSocketClient {
+  return new WebSocketClient({
+    targetPath: `/imserver/${userId}/${index}`,
+    onOpen: (() => {
+      console.log('仪表盘连接已建立!');
+    }),
+    onMessage: ((event) => {
+      console.log('收到新的仪表盘消息:', event.data);
+      // 这里可以添加处理逻辑
+    }),
+    onClose: ((event) => {
+      console.log('仪表盘连接已断开:', event.code, event.reason);
+    }),
+    onError: ((event) => {
+      console.error('仪表盘连接出错，请检查网络:', event);
+    })
+  });
+}


### PR DESCRIPTION
# 修改部分ws代理服务器内置转发规则/删除冗余代码/兼容ChatAPI到最新的http实例/新增Dashboard websocket示例

1. 删除ws代理服务器检测页面关闭而关闭服务器的代码
2. 直接转发原始string，而非包装成JSON，保证一致性
3. 兼容ChatAPI到最新的http实例
4. 新增Dashboard websocket示例


## ✅ 任务清单

- [x] 我已测试了我的更改并确认其功能正常
- [x] 我已更新文档（如有必要）
- [x] 我已检查代码格式并遵循项目的代码风格
- [x] 我已在本地合并主分支并解决所有冲突