### PR TITLE
feat: 完善报价编辑页面表现及侧边栏功能；调整MainLayout样式；引入vueUse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@layui/layui-vue": "^2.22.0",
         "@types/node": "^22.14.1",
+        "@vueuse/core": "^13.9.0",
         "axios": "^1.8.4",
         "chart.js": "^4.5.0",
         "commitizen": "^4.3.1",
@@ -2713,6 +2714,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmmirror.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.32.1",
       "resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
@@ -3291,12 +3298,50 @@
         }
       }
     },
+    "node_modules/@vueuse/core": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmmirror.com/@vueuse/core/-/core-13.9.0.tgz",
+      "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/@vueuse/metadata": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmmirror.com/@vueuse/metadata/-/metadata-13.9.0.tgz",
+      "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@vueuse/metadata": {
       "version": "8.7.3",
       "resolved": "https://registry.npmmirror.com/@vueuse/metadata/-/metadata-8.7.3.tgz",
       "integrity": "sha512-spf9kgCsBEFbQb90I6SIqAWh1yP5T1JoJGj+/04+VTMIHXKzn3iecmHUalg8QEOCPNtnFQGNEw5OLg0L39eizg==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmmirror.com/@vueuse/shared/-/shared-13.9.0.tgz",
+      "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@layui/layui-vue": "^2.22.0",
     "@types/node": "^22.14.1",
+    "@vueuse/core": "^13.9.0",
     "axios": "^1.8.4",
     "chart.js": "^4.5.0",
     "commitizen": "^4.3.1",

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -127,7 +127,7 @@ $sidebarWidthCollapsed: 80px;
       flex: 1;
       height: calc(100vh - $mainContentMarginTop - 20px);
       padding-right: 20px;
-      border-radius: $border-radius-extra-large;
+      border-radius: $border-radius-extra-large 0 0 $border-radius-extra-large;
       transition: margin-left 0.3s ease;
       z-index: 80;
 

--- a/src/pages/design/components/QuotationEdit.vue
+++ b/src/pages/design/components/QuotationEdit.vue
@@ -1,304 +1,314 @@
 <template>
-  <lay-loading :type="2" :loading="isLoading" :delay="500">
-    <lay-card class="quotation-edit-card">
-      <div v-if="enableCustomerInfo">
-        <button class="show-customer-info-btn">
-          <SvgIcon :name="showCustomerInfo ? 'double_up' : 'double_down'"
-            @click="showCustomerInfo = !showCustomerInfo" />
-        </button>
-        <lay-row v-if="showCustomerInfo" :gutter="20">
-          <lay-col :xs="24" :md="12">
-            <!-- 客户信息模块 -->
-            <div class="module-card">
-              <div class="module-header">
-                <h5>客户信息</h5>
+  <main ref="scrollElement" class="scroll-container">
+    <lay-loading :type="2" :loading="isLoading" :delay="500">
+      <lay-card class="quotation-edit-card">
+        <div v-if="enableCustomerInfo">
+          <lay-tooltip position="right" :content="showCustomerInfo ? '收起客户信息' : '显示客户信息'">
+            <button class="show-customer-info-btn">
+              <SvgIcon :name="showCustomerInfo ? 'double_up' : 'double_down'"
+                @click="showCustomerInfo = !showCustomerInfo" />
+            </button>
+          </lay-tooltip>
+          <lay-row v-if="showCustomerInfo" :gutter="20">
+            <lay-col :xs="24" :md="12">
+              <!-- 客户信息模块 -->
+              <div class="module-card">
+                <div class="module-header">
+                  <h5>客户信息</h5>
+                </div>
+                <div class="module-content">
+                  <div class="form-row">
+                    <label class="form-head-label">客户单位</label>
+                    <lay-select placeholder="请选择" v-model="customerName" @change="handleClientChange" allow-clear>
+                      <lay-select-option v-for="client of clientInfoList" :key="client.id" :value="client"
+                        :label="client.contacts" />
+                    </lay-select>
+                    <lay-button type="normal" size="md" class="info-button">
+                      <SvgIcon name="group_chat" width="16" height="16" />
+                      客户详情
+                    </lay-button>
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">客户地址</label>
+                    <lay-input v-model="customerInfo.address" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">联系人员</label>
+                    <lay-input v-model="customerInfo.contact" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">联系电话</label>
+                    <lay-input v-model="customerInfo.phone" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">客户邮箱</label>
+                    <lay-input v-model="customerInfo.email" disabled />
+                    <lay-button type="normal" size="md" class="info-button"
+                      @click="showCustomerBankInfo = !showCustomerBankInfo">
+                      {{ showCustomerBankInfo ? '收起信息' : '账户信息' }}
+                    </lay-button>
+                  </div>
+                  <div v-show="showCustomerBankInfo" class="bank-info-box">
+                    <div class="form-row">
+                      <label class="form-head-label">银行账号</label>
+                      <lay-input v-model="customerInfo.bankAccount" disabled />
+                    </div>
+                    <div class="form-row">
+                      <label class="form-head-label">开户行</label>
+                      <lay-input v-model="customerInfo.bankName" disabled />
+                    </div>
+                    <div class="form-row">
+                      <label class="form-head-label">税号</label>
+                      <lay-input v-model="customerInfo.taxNumber" disabled />
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="module-content">
-                <div class="form-row">
-                  <label class="form-head-label">客户单位</label>
-                  <lay-select placeholder="请选择" v-model="customerName" @change="handleClientChange" allow-clear>
-                    <lay-select-option v-for="client of clientInfoList" :key="client.id" :value="client"
-                      :label="client.contacts" />
-                  </lay-select>
-                  <lay-button type="normal" size="md" class="info-button">
-                    <SvgIcon name="group_chat" width="16" height="16" />
-                    客户详情
-                  </lay-button>
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">客户地址</label>
-                  <lay-input v-model="customerInfo.address" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">联系人员</label>
-                  <lay-input v-model="customerInfo.contact" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">联系电话</label>
-                  <lay-input v-model="customerInfo.phone" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">客户邮箱</label>
-                  <lay-input v-model="customerInfo.email" disabled />
-                  <lay-button type="normal" size="md" class="info-button"
-                    @click="showCustomerBankInfo = !showCustomerBankInfo">
-                    {{ showCustomerBankInfo ? '收起信息' : '账户信息' }}
-                  </lay-button>
-                </div>
-                <div v-show="showCustomerBankInfo" class="bank-info-box">
-                  <div class="form-row">
-                    <label class="form-head-label">银行账号</label>
-                    <lay-input v-model="customerInfo.bankAccount" disabled />
-                  </div>
-                  <div class="form-row">
-                    <label class="form-head-label">开户行</label>
-                    <lay-input v-model="customerInfo.bankName" disabled />
-                  </div>
-                  <div class="form-row">
-                    <label class="form-head-label">税号</label>
-                    <lay-input v-model="customerInfo.taxNumber" disabled />
-                  </div>
-                </div>
-              </div>
-            </div>
 
-            <!-- 项目信息模块 -->
-            <div class="module-card">
-              <div class="module-header">
-                <h5>项目信息</h5>
-              </div>
-              <div class="module-content">
-                <div class="form-row">
-                  <label class="form-head-label required">项目名称</label>
-                  <lay-input v-model="projectInfo.name" placeholder="" />
+              <!-- 项目信息模块 -->
+              <div class="module-card">
+                <div class="module-header">
+                  <h5>项目信息</h5>
                 </div>
-                <div class="form-row">
-                  <label class="form-head-label required">项目负责人</label>
-                  <lay-select v-model="projectInfo.manager" placeholder="请选择" allow-clear>
-                    <lay-select-option v-for="item in projectManagerList" :key="item.id" :value="item.id"
-                      :label="item.name" />
-                  </lay-select>
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label required">报价单类型</label>
-                  <div class="select-group">
-                    <QuoteTypeSelect v-model="projectInfo.quoteType1" :category="1" placeholder="请选择"
-                      ref="quoteTypeSelectRef1" />
-                    <QuoteTypeSelect v-model="projectInfo.quoteType2" :category="2" placeholder="请选择"
-                      ref="quoteTypeSelectRef2" />
-                    <QuoteTypeSelect v-model="projectInfo.quoteType3" :category="3" placeholder="请选择"
-                      ref="quoteTypeSelectRef3" />
+                <div class="module-content">
+                  <div class="form-row">
+                    <label class="form-head-label required">项目名称</label>
+                    <lay-input v-model="projectInfo.name" placeholder="" />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label required">项目负责人</label>
+                    <lay-select v-model="projectInfo.manager" placeholder="请选择" allow-clear>
+                      <lay-select-option v-for="item in projectManagerList" :key="item.id" :value="item.id"
+                        :label="item.name" />
+                    </lay-select>
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label required">报价单类型</label>
+                    <div class="select-group">
+                      <QuoteTypeSelect v-model="projectInfo.quoteType1" :category="1" placeholder="请选择"
+                        ref="quoteTypeSelectRef1" />
+                      <QuoteTypeSelect v-model="projectInfo.quoteType2" :category="2" placeholder="请选择"
+                        ref="quoteTypeSelectRef2" />
+                      <QuoteTypeSelect v-model="projectInfo.quoteType3" :category="3" placeholder="请选择"
+                        ref="quoteTypeSelectRef3" />
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">报价单性质</label>
+                    <lay-select v-model="projectInfo.nature" placeholder="请选择" allow-clear>
+                      <lay-select-option value="初步建议阶段">
+                        初步建议阶段
+                      </lay-select-option>
+                      <lay-select-option value="顾问设计阶段">
+                        顾问设计阶段
+                      </lay-select-option>
+                      <lay-select-option value="项目投标阶段">
+                        项目投标阶段
+                      </lay-select-option>
+                      <lay-select-option value="设备采购阶段">
+                        设备采购阶段
+                      </lay-select-option>
+                    </lay-select>
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">项目备注</label>
+                    <lay-input v-model="projectInfo.remark" />
                   </div>
                 </div>
-                <div class="form-row">
-                  <label class="form-head-label">报价单性质</label>
-                  <lay-select v-model="projectInfo.nature" placeholder="请选择" allow-clear>
-                    <lay-select-option value="初步建议阶段">
-                      初步建议阶段
-                    </lay-select-option>
-                    <lay-select-option value="顾问设计阶段">
-                      顾问设计阶段
-                    </lay-select-option>
-                    <lay-select-option value="项目投标阶段">
-                      项目投标阶段
-                    </lay-select-option>
-                    <lay-select-option value="设备采购阶段">
-                      设备采购阶段
-                    </lay-select-option>
-                  </lay-select>
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">项目备注</label>
-                  <lay-input v-model="projectInfo.remark" />
-                </div>
               </div>
-            </div>
-          </lay-col>
+            </lay-col>
 
-          <lay-col :xs="24" :md="12">
-            <!-- 我司信息模块 -->
-            <div class="module-card">
-              <div class="module-header">
-                <h5>我司信息</h5>
+            <lay-col :xs="24" :md="12">
+              <!-- 我司信息模块 -->
+              <div class="module-card">
+                <div class="module-header">
+                  <h5>我司信息</h5>
+                </div>
+                <div class="module-content">
+                  <div class="form-row">
+                    <label class="form-head-label">设计单位</label>
+                    <lay-input v-model="companyInfo.name" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">企业地址</label>
+                    <lay-input v-model="companyInfo.address" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">联系人员</label>
+                    <lay-input v-model="companyInfo.contact" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">联系电话</label>
+                    <lay-input v-model="companyInfo.phone" disabled />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">邮箱地址</label>
+                    <lay-input v-model="companyInfo.email" disabled />
+                    <lay-button type="normal" size="md" class="info-button"
+                      @click="showCompanyBankInfo = !showCompanyBankInfo">
+                      {{ showCompanyBankInfo ? '收起信息' : '账户信息' }}
+                    </lay-button>
+                  </div>
+                  <div v-show="showCompanyBankInfo" class="bank-info-box">
+                    <div class="form-row">
+                      <label class="form-head-label">我司银行账号</label>
+                      <lay-input v-model="companyInfo.bankAccount" disabled />
+                    </div>
+                    <div class="form-row">
+                      <label class="form-head-label">我司开户行</label>
+                      <lay-input v-model="companyInfo.bankName" disabled />
+                    </div>
+                    <div class="form-row">
+                      <label class="form-head-label">我司税号</label>
+                      <lay-input v-model="companyInfo.taxNumber" disabled />
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="module-content">
-                <div class="form-row">
-                  <label class="form-head-label">设计单位</label>
-                  <lay-input v-model="companyInfo.name" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">企业地址</label>
-                  <lay-input v-model="companyInfo.address" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">联系人员</label>
-                  <lay-input v-model="companyInfo.contact" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">联系电话</label>
-                  <lay-input v-model="companyInfo.phone" disabled />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">邮箱地址</label>
-                  <lay-input v-model="companyInfo.email" disabled />
-                  <lay-button type="normal" size="md" class="info-button"
-                    @click="showCompanyBankInfo = !showCompanyBankInfo">
-                    {{ showCompanyBankInfo ? '收起信息' : '账户信息' }}
-                  </lay-button>
-                </div>
-                <div v-show="showCompanyBankInfo" class="bank-info-box">
-                  <div class="form-row">
-                    <label class="form-head-label">我司银行账号</label>
-                    <lay-input v-model="companyInfo.bankAccount" disabled />
-                  </div>
-                  <div class="form-row">
-                    <label class="form-head-label">我司开户行</label>
-                    <lay-input v-model="companyInfo.bankName" disabled />
-                  </div>
-                  <div class="form-row">
-                    <label class="form-head-label">我司税号</label>
-                    <lay-input v-model="companyInfo.taxNumber" disabled />
-                  </div>
-                </div>
-              </div>
-            </div>
 
-            <!-- 交易信息模块 -->
-            <div class="module-card">
-              <div class="module-header">
-                <h5>交易信息</h5>
-              </div>
-              <div class="module-content">
-                <div class="form-row">
-                  <label class="form-head-label">交货方式</label>
-                  <lay-select v-model="tradeInfo.deliveryMethod" placeholder="请选择" allow-clear>
-                    <lay-select-option value="货到付款">
-                      货到付款
-                    </lay-select-option>
-                    <lay-select-option value="款到发货">
-                      款到发货
-                    </lay-select-option>
-                    <lay-select-option value="其它">其它</lay-select-option>
-                  </lay-select>
+              <!-- 交易信息模块 -->
+              <div class="module-card">
+                <div class="module-header">
+                  <h5>交易信息</h5>
                 </div>
-                <div class="form-row">
-                  <label class="form-head-label">交货时间</label>
-                  <lay-date-picker v-model="tradeInfo.deliveryTime" placeholder="点击选择交货时间" allow-clear />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">交货地点</label>
-                  <AreaSelect v-model="tradeInfo.area" />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">详细地址</label>
-                  <lay-input v-model="tradeInfo.address" placeholder="" />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">结算方式</label>
-                  <lay-select v-model="tradeInfo.paymentMethod" placeholder="请选择" allow-clear>
-                    <lay-select-option v-for="item in settleList" :key="item.id" :value="item.id"
-                      :label="item.method" />
-                  </lay-select>
-                </div>
-              </div>
-            </div>
-          </lay-col>
-        </lay-row>
-      </div>
-      <div v-else>
-        <!-- 显示简单的报价单信息 -->
-        <lay-row v-if="showCustomerInfo" :gutter="20">
-          <lay-col :xs="24" :md="12">
-            <!-- 客户信息模块 -->
-            <div class="module-card">
-              <div class="module-content">
-                <div class="form-row">
-                  <label class="form-head-label required">模块名</label>
-                  <lay-input v-model="modelInfo.name" />
-                </div>
-                <div class="form-row">
-                  <label class="form-head-label">供应商信息</label>
-                  <lay-select v-model="modelInfo.gyClient" placeholder="请选择" allow-clear>
-                    <lay-select-option value="option1" label="选项1" />
-                  </lay-select>
-                  <lay-button type="normal" size="md" class="info-button">
-                    供应商
-                  </lay-button>
-                  <lay-button type="normal" size="md" class="info-button">
-                    详情
-                  </lay-button>
+                <div class="module-content">
+                  <div class="form-row">
+                    <label class="form-head-label">交货方式</label>
+                    <lay-select v-model="tradeInfo.deliveryMethod" placeholder="请选择" allow-clear>
+                      <lay-select-option value="货到付款">
+                        货到付款
+                      </lay-select-option>
+                      <lay-select-option value="款到发货">
+                        款到发货
+                      </lay-select-option>
+                      <lay-select-option value="其它">其它</lay-select-option>
+                    </lay-select>
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">交货时间</label>
+                    <lay-date-picker v-model="tradeInfo.deliveryTime" placeholder="点击选择交货时间" allow-clear />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">交货地点</label>
+                    <AreaSelect v-model="tradeInfo.area" />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">详细地址</label>
+                    <lay-input v-model="tradeInfo.address" placeholder="" />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">结算方式</label>
+                    <lay-select v-model="tradeInfo.paymentMethod" placeholder="请选择" allow-clear>
+                      <lay-select-option v-for="item in settleList" :key="item.id" :value="item.id"
+                        :label="item.method" />
+                    </lay-select>
+                  </div>
                 </div>
               </div>
-            </div>
-          </lay-col>
-          <lay-col :xs="24" :md="12">
-            <!-- 客户信息模块 -->
-            <div class="module-card">
-              <div class="module-content">
-                <div class="form-row">
-                  <QuoteTypeSelect v-model="modelInfo.ordersType1" :category="1"
-                    :orders-id="enableCustomerInfo ? '' : modelData.ordersId" placeholder="请选择" />
-                  <QuoteTypeSelect v-model="modelInfo.ordersType3" :category="3"
-                    :orders-id="enableCustomerInfo ? '' : modelData.ordersId" placeholder="请选择" />
-                </div>
-              </div>
-            </div>
-          </lay-col>
-        </lay-row>
-      </div>
-      <lay-row :gutter="20">
-        <div class="module-card">
-          <div class="module-header">
-            <h5>报价目录</h5>
-            <div class="module-header-toolbar">
-              <button v-for="btn of quotationMenuConfig" :key="btn.name" class="toolbar-btn" :title="btn.name"
-                @click="btn.btnAction">
-                <SvgIcon :name="btn.iconName" width="1.25rem" height="1.25rem" />
-              </button>
-            </div>
-          </div>
-          <div class="module-content">
-            <!-- 表格区域 -->
-            <AdvancedTable :columns="quotationColumns" :data-source="quotationData as Record<string, unknown>[]"
-              :enable-drag="true" :pagination="false" :show-toolbar="false" :row-key="'id'" :responsive="true"
-              @update:data-source="handleQuotationDataUpdate" @cell-update="handleCellUpdate" @row-drag="handleRowDrag"
-              @button-click="handleButtonClick" @row-click="handleRowClick" />
-            <!-- 成本统计-->
-            <div class="cost-statistics">
-              <div class="cost-statistics-item">
-                <span class="cost-statistics-item-label">总成本合计 (A): </span>
-                <span class="cost-statistics-item-value">{{ costStatistics.totalCost.toFixed(2) }}</span>
-              </div>
-              <div class="cost-statistics-item">
-                <span class="cost-statistics-item-label">总售价合计 (B): </span>
-                <span class="cost-statistics-item-value">{{ costStatistics.totalPrice.toFixed(2) }}</span>
-              </div>
-              <div class="cost-statistics-item">
-                <span class="cost-statistics-item-label">毛利率 (B - A) / B: </span>
-                <span class="cost-statistics-item-value">{{ ((costStatistics.totalPrice ? (costStatistics.totalPrice -
-                  costStatistics.totalCost) / costStatistics.totalPrice : 0) * 100).toFixed(2) }}%</span>
-              </div>
-              <div class="cost-statistics-item">
-                <span class="cost-statistics-item-label">开项: </span>
-                <span class="cost-statistics-item-value">{{ openItemCount }}</span>
-              </div>
-            </div>
-          </div>
+            </lay-col>
+          </lay-row>
         </div>
-      </lay-row>
-    </lay-card>
-    <SideToolbar />
+        <div v-else>
+          <!-- 显示简单的报价单信息 -->
+          <lay-row v-if="showCustomerInfo" :gutter="20">
+            <lay-col :xs="24" :md="12">
+              <!-- 客户信息模块 -->
+              <div class="module-card">
+                <div class="module-content">
+                  <div class="form-row">
+                    <label class="form-head-label required">模块名</label>
+                    <lay-input v-model="modelInfo.name" />
+                  </div>
+                  <div class="form-row">
+                    <label class="form-head-label">供应商信息</label>
+                    <lay-select v-model="modelInfo.gyClient" placeholder="请选择" allow-clear>
+                      <lay-select-option value="option1" label="选项1" />
+                    </lay-select>
+                    <lay-button type="normal" size="md" class="info-button">
+                      供应商
+                    </lay-button>
+                    <lay-button type="normal" size="md" class="info-button">
+                      详情
+                    </lay-button>
+                  </div>
+                </div>
+              </div>
+            </lay-col>
+            <lay-col :xs="24" :md="12">
+              <!-- 客户信息模块 -->
+              <div class="module-card">
+                <div class="module-content">
+                  <div class="form-row">
+                    <QuoteTypeSelect v-model="modelInfo.ordersType1" :category="1"
+                      :orders-id="enableCustomerInfo ? '' : modelData.ordersId" placeholder="请选择" />
+                    <QuoteTypeSelect v-model="modelInfo.ordersType3" :category="3"
+                      :orders-id="enableCustomerInfo ? '' : modelData.ordersId" placeholder="请选择" />
+                  </div>
+                </div>
+              </div>
+            </lay-col>
+          </lay-row>
+        </div>
+        <lay-row :gutter="20">
+          <div class="module-card">
+            <div class="module-header">
+              <h5>报价目录</h5>
+              <div class="module-header-toolbar">
+                <lay-tooltip position="top" v-for="btn of quotationMenuConfig" :key="btn.name" :content="btn.name">
+                  <button class="toolbar-btn" @click="btn.btnAction">
+                    <SvgIcon :name="btn.iconName" width="1.25rem" height="1.25rem" />
+                  </button>
+                </lay-tooltip>
+              </div>
+            </div>
+            <div class="module-content">
+              <!-- 表格区域 -->
+              <AdvancedTable :columns="quotationColumns" :data-source="quotationData as Record<string, unknown>[]"
+                :enable-drag="true" :pagination="false" :show-toolbar="false" :row-key="'id'" :responsive="true"
+                @update:data-source="handleQuotationDataUpdate" @cell-update="handleCellUpdate"
+                @row-drag="handleRowDrag" @button-click="handleButtonClick" @row-click="handleRowClick" />
+              <!-- 成本统计-->
+              <div class="cost-statistics">
+                <div class="cost-statistics-item">
+                  <span class="cost-statistics-item-label">总成本合计 (A): </span>
+                  <span class="cost-statistics-item-value">{{ costStatistics.totalCost.toFixed(2) }}</span>
+                </div>
+                <div class="cost-statistics-item">
+                  <span class="cost-statistics-item-label">总售价合计 (B): </span>
+                  <span class="cost-statistics-item-value">{{ costStatistics.totalPrice.toFixed(2) }}</span>
+                </div>
+                <div class="cost-statistics-item">
+                  <span class="cost-statistics-item-label">毛利率 (B - A) / B: </span>
+                  <span class="cost-statistics-item-value">{{ ((costStatistics.totalPrice ? (costStatistics.totalPrice
+                    -
+                    costStatistics.totalCost) / costStatistics.totalPrice : 0) * 100).toFixed(2) }}%</span>
+                </div>
+                <div class="cost-statistics-item">
+                  <span class="cost-statistics-item-label">开项: </span>
+                  <span class="cost-statistics-item-value">{{ openItemCount }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </lay-row>
+      </lay-card>
 
-    <!-- 新建子项目 drawer -->
-    <SubProjectDrawer v-model:visible="showSubProjectDrawer" @submit="handleSubProjectSubmit" />
+      <!-- 新建子项目 drawer -->
+      <SubProjectDrawer v-model:visible="showSubProjectDrawer" @submit="handleSubProjectSubmit" />
 
-    <!-- 产品利率输入弹窗 -->
-    <ProductInterestRateDialog v-model:visible="showProductInterestRateDialog"
-      @confirm="handleProductInterestRateConfirm" />
+      <!-- 产品利率输入弹窗 -->
+      <ProductInterestRateDialog v-model:visible="showProductInterestRateDialog"
+        @confirm="handleProductInterestRateConfirm" />
 
-    <!-- 产品选择模态框 -->
-    <ProductSelectModal ref="productSelectModalRef" @select="handleProductSelect" @cancel="handleProductSelectCancel" />
-  </lay-loading>
+      <!-- 产品选择模态框 -->
+      <ProductSelectModal ref="productSelectModalRef" @select="handleProductSelect"
+        @cancel="handleProductSelectCancel" />
+    </lay-loading>
+
+
+    <!-- 侧边控制工具栏 -->
+    <SideToolbar @scrollToTop="scrollToTop" @scrollToBottom="scrollToBottom" />
+  </main>
 </template>
 
 <script setup lang="ts">
@@ -342,6 +352,8 @@ import clientApi from '@/api/client/clinetApi';
 import type { OrderProduct } from '@/api/product/productApi.type';
 import CompanyLinkCell from '@/components/table-cells/CompanyLinkCell.vue';
 import env from '@/utils/env';
+import { useScroll } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
 // 报价目录菜单配置
 interface ButtonAction {
@@ -1274,6 +1286,25 @@ onMounted(async () => {
     isLoading.value = false;
   }
 });
+
+const scrollElement = useTemplateRef<HTMLElement>('scrollElement')
+const { x, y } = useScroll(scrollElement, { behavior: 'smooth' })
+
+// 侧边栏相关控制
+const scrollToTop = () => {
+  console.log('scrollToTop1', x.value, y.value);
+  y.value = 0;
+  console.log('scrollToTop2', x.value, y.value);
+};
+
+const scrollToBottom = () => {
+  console.log('scrollToBottom11', x.value, y.value);
+  if (scrollElement.value) {
+    console.log('scrollToBottom22', x.value, y.value);
+    y.value = scrollElement.value.scrollHeight;
+    console.log('scrollToBottom33', x.value, y.value);
+  }
+};
 </script>
 
 <style scoped lang="scss">
@@ -1309,13 +1340,14 @@ onMounted(async () => {
 }
 
 .quotation-edit-card {
+  height: 100%;
   position: relative;
 
   .show-customer-info-btn {
     @include button-style($primary-color);
     color: #949494;
     position: absolute;
-    top: 20px;
+    top: 25px;
     left: 0;
     padding: 10px;
     z-index: 10;
@@ -1433,5 +1465,18 @@ onMounted(async () => {
       }
     }
   }
+}
+
+/* 滚动容器样式 */
+.scroll-container {
+  height: 100%;
+  /* 减去顶部导航和其他元素的高度 */
+  overflow-y: auto;
+  overflow-x: hidden;
+  scroll-behavior: smooth;
+  border-radius: $border-radius-extra-large;
+  padding-right: 20px;
+  margin-right: -20px;
+  background-clip: content-box;
 }
 </style>

--- a/src/pages/design/components/QuotationEdit.vue
+++ b/src/pages/design/components/QuotationEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <main ref="scrollElement" class="scroll-container">
-    <lay-loading :type="2" :loading="isLoading" :delay="500">
+    <lay-loading :type="2" :loading="isLoading" :delay="0" class="loading-container">
       <lay-card class="quotation-edit-card">
         <div v-if="enableCustomerInfo">
           <lay-tooltip position="right" :content="showCustomerInfo ? '收起客户信息' : '显示客户信息'">
@@ -305,9 +305,8 @@
         @cancel="handleProductSelectCancel" />
     </lay-loading>
 
-
     <!-- 侧边控制工具栏 -->
-    <SideToolbar @scrollToTop="scrollToTop" @scrollToBottom="scrollToBottom" />
+    <SideToolbar v-show="!isLoading" @scrollToTop="scrollToTop" @scrollToBottom="scrollToBottom" />
   </main>
 </template>
 
@@ -1465,6 +1464,10 @@ const scrollToBottom = () => {
       }
     }
   }
+}
+
+.loading-container {
+  height: 100%;
 }
 
 /* 滚动容器样式 */

--- a/src/pages/design/components/QuotationEdit.vue
+++ b/src/pages/design/components/QuotationEdit.vue
@@ -306,7 +306,13 @@
     </lay-loading>
 
     <!-- 侧边控制工具栏 -->
-    <SideToolbar v-show="!isLoading" @scrollToTop="scrollToTop" @scrollToBottom="scrollToBottom" />
+    <SideToolbar v-show="!isLoading" @scrollToTop="scrollToTop" @scrollToBottom="scrollToBottom"
+      @collapse-all-sub-items="collapseAllSubItems" @toggle-total-price-preview="toggleTotalPricePreview" />
+
+    <!-- 总价预览 -->
+    <TotalPricePreview v-show="isTotalPricePreviewVisible"
+      :product-rate="productInterestRate?.useDefaultPrice ? defaultInterestRate : productInterestRate?.interestRate"
+      :total-cost="costStatistics.totalCost" :total-price="costStatistics.totalPrice" />
   </main>
 </template>
 
@@ -323,6 +329,7 @@ import SubProjectAddCell from '@/components/table-cells/SubProjectAddCell.vue';
 import SubProjectDrawer from './SubProjectDrawer.vue';
 import ProductInterestRateDialog from './ProductInterestRateDialog.vue';
 import ProductSelectModal from './ProductSelectModal.vue';
+import TotalPricePreview from './TotalPricePreview.vue';
 import { onMounted, ref, markRaw, watch, computed } from 'vue';
 import type {
   OrderModuleListResponse,
@@ -1287,22 +1294,31 @@ onMounted(async () => {
 });
 
 const scrollElement = useTemplateRef<HTMLElement>('scrollElement')
-const { x, y } = useScroll(scrollElement, { behavior: 'smooth' })
+const { y } = useScroll(scrollElement, { behavior: 'smooth' })
 
 // 侧边栏相关控制
 const scrollToTop = () => {
-  console.log('scrollToTop1', x.value, y.value);
   y.value = 0;
-  console.log('scrollToTop2', x.value, y.value);
 };
 
 const scrollToBottom = () => {
-  console.log('scrollToBottom11', x.value, y.value);
   if (scrollElement.value) {
-    console.log('scrollToBottom22', x.value, y.value);
     y.value = scrollElement.value.scrollHeight;
-    console.log('scrollToBottom33', x.value, y.value);
   }
+};
+
+// 控制折叠/展开所有子项目
+const isAllSubItemsCollapsed = ref(false);
+const collapseAllSubItems = (isCollapsed: boolean) => {
+  isAllSubItemsCollapsed.value = isCollapsed;
+  console.log('isAllSubItemsCollapsed', isAllSubItemsCollapsed.value);
+
+};
+
+// 控制总价预览展示与否
+const isTotalPricePreviewVisible = ref(false);
+const toggleTotalPricePreview = () => {
+  isTotalPricePreviewVisible.value = !isTotalPricePreviewVisible.value;
 };
 </script>
 

--- a/src/pages/design/components/SideToolbar.vue
+++ b/src/pages/design/components/SideToolbar.vue
@@ -22,6 +22,7 @@
 
 <script setup lang="ts">
 import SvgIcon from '@/components/SvgIcon.vue';
+import { computed, ref, type ComputedRef } from 'vue';
 
 interface SideToolbarItem {
   iconName: string;
@@ -35,8 +36,11 @@ const scrollToTop = () => {
   emits('scrollToTop');
 };
 
+const isAllSubItemsCollapsed = ref(false);
+
 const collapseAllSubItems = () => {
-  emits('collapseAllSubItems');
+  isAllSubItemsCollapsed.value = !isAllSubItemsCollapsed.value;
+  emits('collapseAllSubItems', isAllSubItemsCollapsed.value);
 };
 
 const toggleTotalPricePreview = () => {
@@ -63,11 +67,10 @@ const scrollToBottom = () => {
   emits('scrollToBottom');
 };
 
-
-const sideToolbarConfig: SideToolbarItem[] = [
+const sideToolbarConfig: ComputedRef<SideToolbarItem[]> = computed(() => [
   {
-    iconName: 'shrink_item',
-    name: '折叠所有子项目',
+    iconName: isAllSubItemsCollapsed.value ? 'enlarge_item' : 'shrink_item',
+    name: isAllSubItemsCollapsed.value ? '展开所有子项目' : '折叠所有子项目',
     btnAction: collapseAllSubItems,
   },
   {
@@ -95,7 +98,7 @@ const sideToolbarConfig: SideToolbarItem[] = [
     name: '临时产品载入数据库',
     btnAction: loadTempProductIntoDatabase,
   },
-]
+]);
 </script>
 
 <style scoped lang="scss">

--- a/src/pages/design/components/SideToolbar.vue
+++ b/src/pages/design/components/SideToolbar.vue
@@ -1,39 +1,106 @@
 <template>
   <div class="side-toolbar">
-    <div class="side-toolbar-item" title="返回顶部">
-      <SvgIcon name="expand_light_reverse" />
-    </div>
-    <div class="side-toolbar-item" title="折叠所有子项目">
-      <SvgIcon name="shrink_item" />
-    </div>
-    <div class="side-toolbar-item" title="总价预览">
-      <SvgIcon name="rmb" />
-    </div>
-    <div class="side-toolbar-item" title="提取模块">
-      <SvgIcon name="plus" />
-    </div>
-    <div class="side-toolbar-item" title="查看方案云">
-      <SvgIcon name="query" />
-    </div>
-    <div class="side-toolbar-item" title="导入模块">
-      <SvgIcon name="order_receive_order" />
-    </div>
-    <div class="side-toolbar-item" title="临时产品载入数据库">
-      <SvgIcon name="house_manager" />
-    </div>
-    <div class="side-toolbar-item" title="返回底部">
-      <SvgIcon name="expand_light" />
-    </div>
+    <lay-tooltip position="left" content="返回顶部">
+      <div class="side-toolbar-item" @click="scrollToTop">
+        <SvgIcon name="expand_light_reverse" />
+      </div>
+    </lay-tooltip>
+
+    <lay-tooltip position="left" v-for="btn of sideToolbarConfig" :key="btn.name" :content="btn.name">
+      <div class="side-toolbar-item" @click="btn.btnAction">
+        <SvgIcon :name="btn.iconName" />
+      </div>
+    </lay-tooltip>
+
+    <lay-tooltip position="left" content="返回底部">
+      <div class="side-toolbar-item" @click="scrollToBottom">
+        <SvgIcon name="expand_light" />
+      </div>
+    </lay-tooltip>
   </div>
 </template>
 
 <script setup lang="ts">
 import SvgIcon from '@/components/SvgIcon.vue';
+
+interface SideToolbarItem {
+  iconName: string;
+  name: string;
+  btnAction: () => void;
+}
+
+const emits = defineEmits(['scrollToTop', 'collapseAllSubItems', 'toggleTotalPricePreview', 'extractModule', 'toggleSchemeCloud', 'toggleImportModulePanel', 'loadTempProductIntoDatabase', 'scrollToBottom']);
+
+const scrollToTop = () => {
+  emits('scrollToTop');
+};
+
+const collapseAllSubItems = () => {
+  emits('collapseAllSubItems');
+};
+
+const toggleTotalPricePreview = () => {
+  emits('toggleTotalPricePreview');
+};
+
+const extractModule = () => {
+  emits('extractModule');
+};
+
+const toggleSchemeCloud = () => {
+  emits('toggleSchemeCloud');
+};
+
+const toggleImportModulePanel = () => {
+  emits('toggleImportModulePanel');
+};
+
+const loadTempProductIntoDatabase = () => {
+  emits('loadTempProductIntoDatabase');
+};
+
+const scrollToBottom = () => {
+  emits('scrollToBottom');
+};
+
+
+const sideToolbarConfig: SideToolbarItem[] = [
+  {
+    iconName: 'shrink_item',
+    name: '折叠所有子项目',
+    btnAction: collapseAllSubItems,
+  },
+  {
+    iconName: 'rmb',
+    name: '总价预览',
+    btnAction: toggleTotalPricePreview,
+  },
+  {
+    iconName: 'plus',
+    name: '提取模块',
+    btnAction: extractModule,
+  },
+  {
+    iconName: 'query',
+    name: '查看方案云',
+    btnAction: toggleSchemeCloud,
+  },
+  {
+    iconName: 'order_receive_order',
+    name: '导入模块',
+    btnAction: toggleImportModulePanel,
+  },
+  {
+    iconName: 'house_manager',
+    name: '临时产品载入数据库',
+    btnAction: loadTempProductIntoDatabase,
+  },
+]
 </script>
 
 <style scoped lang="scss">
 .side-toolbar {
-  position: fixed;
+  position: absolute;
   top: 50%;
   transform: translate(0%, -50%);
   right: 0;

--- a/src/pages/design/components/TotalPricePreview.vue
+++ b/src/pages/design/components/TotalPricePreview.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="total-price-preview">
+    <div class="total-price-preview-item">
+      <strong>预设产品利率：</strong><span>{{ isDefaultProductInterestRate ? '默认市场指导价' : productRate.toFixed(2) }}%</span>
+    </div>
+    <div class="total-price-preview-item">
+      <strong>总售价合计：</strong><span>¥ {{ totalPrice.toFixed(2) }}</span>
+    </div>
+    <div class="total-price-preview-item">
+      <strong>总成本合计：</strong><span>¥ {{ totalCost.toFixed(2) }}</span>
+    </div>
+    <div class="total-price-preview-item">
+      <strong>合计毛利润：</strong><span>¥ {{ (totalPrice - totalCost).toFixed(2) }}</span>
+    </div>
+    <div class="total-price-preview-item">
+      <strong>毛利率：</strong><span>{{ totalPrice === 0 ? '0.00' : ((totalPrice - totalCost) / totalPrice * 100).toFixed(2)
+      }}%</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { productRate, totalCost, totalPrice } = defineProps({
+  isDefaultProductInterestRate: {
+    type: Boolean,
+    default: false,
+  },
+  productRate: {
+    type: Number,
+    default: 0,
+  },
+  totalCost: {
+    type: Number,
+    default: 0,
+  },
+  totalPrice: {
+    type: Number,
+    default: 0,
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.total-price-preview {
+  padding: 12px;
+  background-color: #fff;
+  border-radius: 12px;
+  border: 1px solid $border-color-light;
+  box-shadow: $box-shadow-base;
+  font-size: 14px;
+  color: #333;
+
+  position: absolute;
+  top: 50%;
+  transform: translate(0%, -70%);
+  right: 50px;
+
+  .total-price-preview-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 2px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+</style>

--- a/src/pages/design/history-quote/index.vue
+++ b/src/pages/design/history-quote/index.vue
@@ -140,7 +140,8 @@
     </ModalWindow>
 
     <!-- 编辑弹窗 -->
-    <ModalWindow :visible="editModalVisible" title="编辑报价单" :is-teleport="true" @close="editModalVisible = false">
+    <ModalWindow :visible="editModalVisible" title="编辑报价单" :is-teleport="true" @close="editModalVisible = false"
+      :syncHeight="true">
       <QuotationEdit :showCustomerInfoDefault="false" :is-new-quotation="false" @save="handleEditSave"
         :providedOrderId="selectedOrderId" @cancel="editModalVisible = false" />
     </ModalWindow>

--- a/src/pages/design/new-quote/index.vue
+++ b/src/pages/design/new-quote/index.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="new-quote-page">
-    <QuotationEdit
-      ref="quotationEditRef"
-      :quotation-menu-config="quotationMenuConfig"
-      :is-new-quotation="true"
-      @data-submit="handleDataSubmit"
-      @temp-save="handleTempSave"
-    />
+    <QuotationEdit ref="quotationEditRef" :quotation-menu-config="quotationMenuConfig" :is-new-quotation="true"
+      @data-submit="handleDataSubmit" @temp-save="handleTempSave" />
   </div>
 </template>
 
@@ -241,4 +236,9 @@ const handleTempSave = async (data: Quotation) => {
 };
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.new-quote-page {
+  height: calc(100%);
+  border-radius: $border-radius-extra-large;
+}
+</style>

--- a/src/pages/design/temp-quote/index.vue
+++ b/src/pages/design/temp-quote/index.vue
@@ -79,7 +79,8 @@
     </lay-card>
 
     <!-- 编辑弹窗 -->
-    <ModalWindow :visible="editModalVisible" title="编辑报价单" :is-teleport="true" @close="editModalVisible = false">
+    <ModalWindow :visible="editModalVisible" title="编辑报价单" :is-teleport="true" @close="editModalVisible = false"
+      :syncHeight="true">
       <QuotationEdit :showCustomerInfoDefault="false" :is-new-quotation="false" @save="handleEditSave"
         @cancel="editModalVisible = false" :providedOrderId="selectedOrderId" />
     </ModalWindow>


### PR DESCRIPTION
- 报价编辑侧边栏支持返回顶部和底部

- 优化报价编辑相关tooltip体验

- 调整报价编辑加载样式

- 初步引入侧边栏价格显示

- 【Global】去除MainLayout右上、右下圆角，避免裁切某些页面的滚动条

- 【Global】引入vueUse实用组合式工具库，文档可参考https://vueuse.org.cn/

- **本次更新引入新的库，拉取后请先`npm install`安装依赖**